### PR TITLE
Use hackney as the default adapter for GoogleApiClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ This project provides:
 
 ## Installation
 
-Add `:broadway_cloud_pub_sub` to the list of dependencies in `mix.exs`, along with the authentication
-library of your choice (defaults to `:goth`):
+Add `:broadway_cloud_pub_sub` to the list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -29,18 +28,7 @@ def deps do
   ]
 end
 ```
-
-By default, `:goth` will include `:hackney` as its HTTP client. If you choose to use an alternative
-authentication library, you may need to explicitly include an HTTP client (such as `:hackney`):
-
-```elixir
-def deps do
-  [
-    {:broadway_cloud_pub_sub, "~> 0.3.0"},
-    {:hackney, "~> 1.9"}
-  ]
-end
-```
+> Note the [goth](https://hexdocs.pm/goth) package, which handles Google Authentication, is required for the default token implementation.
 
 ## Usage
 
@@ -60,6 +48,18 @@ Broadway.start_link(
 )
 ```
 
-For more information, please see the docs for [Broadway](https://hexdocs.pm/broadway).
+## License
 
-There is also an example app available at: [https://github.com/mcrumm/broadway_cloud_pub_sub_example](https://github.com/mcrumm/broadway_cloud_pub_sub_example)
+Copyright 2019 Plataformatec
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,8 @@ defmodule BroadwayCloudPubSub.MixProject do
     [
       {:broadway, "~> 0.3.0"},
       {:google_api_pub_sub, "~> 0.4"},
+      {:tesla, "~> 1.2.0"},
+      {:hackney, "~> 1.6"},
       {:goth, "~> 0.6", optional: true},
       {:uuid, "~> 1.0", only: :test},
       {:junit_formatter, "~> 3.0", only: [:test]},

--- a/test/broadway_cloud_pub_sub/google_api_client_test.exs
+++ b/test/broadway_cloud_pub_sub/google_api_client_test.exs
@@ -143,6 +143,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
       %{
         pid: test_pid,
         opts: [
+          __internal_tesla_adapter__: Tesla.Mock,
           subscription: "projects/foo/subscriptions/bar",
           token_module: FakeToken
         ]
@@ -235,6 +236,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
       %{
         pid: test_pid,
         opts: [
+          __internal_tesla_adapter__: Tesla.Mock,
           subscription: "projects/foo/subscriptions/bar",
           token_module: FakeToken
         ]


### PR DESCRIPTION
This PR handles the adapter overrides for the `Tesla.Client` structs built by the `:google_api_pub_sub` library.  This change makes hackney the HTTP adapter for BroadwayCloudPubSub connections.  To accommodate this, hackney is now a required dependency for `:broadway_cloud_pub_sub`, along with Tesla 1.2.

To ensure we could still replace the Tesla adapter with the mock adapter in our tests, I exposed a `:connection` option for `GoogleApiClient`, but I purposefully did not document it, as it's really not intended to be overridden by a user-level implementation. Better to document it as an internal option, or leave it as-is?

Closes #18 