### PR TITLE
Remove unused junit_formatter dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,6 @@ defmodule BroadwayCloudPubSub.MixProject do
       {:google_api_pub_sub, "~> 0.11"},
       {:hackney, "~> 1.6"},
       {:goth, "~> 1.0", optional: true},
-      {:junit_formatter, "~> 3.0", only: [:test]},
       {:ex_doc, ">= 0.19.0", only: :docs}
     ]
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,1 @@
-ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
-
 ExUnit.start()


### PR DESCRIPTION
@mcrumm we needed this for the old CircleCI setup or you used it for
development by any chance? Let me know if we can remove it!