### PR TITLE
Fix handling Goth token

### DIFF
--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -205,7 +205,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
   defp validate_scope(opts) do
     with {:ok, scope} <- validate(opts, :scope, @default_scope) do
       ensure_goth_loaded()
-      {:ok, {Goth.Token, :for_scope, [scope]}}
+      {:ok, {__MODULE__, :generate_goth_token, [scope]}}
     end
   end
 
@@ -250,5 +250,12 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
 
   defp validate_sub_parts(_, subscription) do
     validation_error(:subscription, "an valid subscription name", subscription)
+  end
+
+  @doc false
+  def generate_goth_token(scope) do
+    with {:ok, %{token: token}} <- Goth.Token.for_scope(scope) do
+      {:ok, token}
+    end
   end
 end

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -25,8 +25,8 @@ defmodule BroadwayCloudPubSub.Producer do
        Note: The `:scope` option only applies to the default token generator.
 
     * `:token_generator` - Optional. An MFArgs tuple that will be called before each request
-      to fetch an authentication token. It should return `{:ok, String.t()} | :error`.
-      Default is `{Goth.Token, :for_scope, ["https://www.googleapis.com/auth/pubsub"]}`.
+      to fetch an authentication token. It should return `{:ok, String.t()} | {:error, any()}`.
+      Default generator uses `Goth.Token.for_scope/1` with the `"https://www.googleapis.com/auth/pubsub"`.
 
   ## Additional options
 

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -26,7 +26,7 @@ defmodule BroadwayCloudPubSub.Producer do
 
     * `:token_generator` - Optional. An MFArgs tuple that will be called before each request
       to fetch an authentication token. It should return `{:ok, String.t()} | {:error, any()}`.
-      Default generator uses `Goth.Token.for_scope/1` with the `"https://www.googleapis.com/auth/pubsub"`.
+      Default generator uses `Goth.Token.for_scope/1` with `"https://www.googleapis.com/auth/pubsub"`.
 
   ## Additional options
 

--- a/test/broadway_cloud_pub_sub/google_api_client_test.exs
+++ b/test/broadway_cloud_pub_sub/google_api_client_test.exs
@@ -144,13 +144,14 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
       assert message == "expected :scope to be a non empty string, got: 1"
     end
 
-    test ":token_generator defaults to Goth.Token with default scope" do
+    test ":token_generator defaults to using Goth with default scope" do
       opts = [subscription: "projects/foo/subscriptions/bar"]
 
       {:ok, result} = GoogleApiClient.init(opts)
 
       assert result.token_generator ==
-               {Goth.Token, :for_scope, ["https://www.googleapis.com/auth/pubsub"]}
+               {BroadwayCloudPubSub.GoogleApiClient, :generate_goth_token,
+                ["https://www.googleapis.com/auth/pubsub"]}
     end
 
     test ":token_generator should be a tuple {Mod, Fun, Args}" do


### PR DESCRIPTION
Our generator contract is `{:ok, String.t()}` but
`Goth.Token.for_scope/1` is returning `{:ok, %{token: String.t(), ...}}`
so I added a wrapper function.