### PR TITLE
Add support for configuring the acking behaviour

### DIFF
--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -141,10 +141,10 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
     )
   end
 
-  defp apply_ack_func(:no_ack, messages, opts),
-    do: apply_ack_func({:no_ack, 0}, messages, opts)
+  defp apply_ack_func(:nack, messages, opts),
+    do: apply_ack_func({:nack, 0}, messages, opts)
 
-  defp apply_ack_func({:no_ack, deadline}, messages, opts) do
+  defp apply_ack_func({:nack, deadline}, messages, opts) do
     ack_ids = Enum.map(messages, &extract_ack_id/1)
 
     opts
@@ -260,8 +260,8 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
 
   defp validate_acking(:ack), do: {:ok, :ack}
   defp validate_acking(:ignore), do: {:ok, :ignore}
-  defp validate_acking(:no_ack), do: {:ok, {:no_ack, 0}}
-  defp validate_acking({:no_ack, n}) when is_integer(n) and n >= 0, do: {:ok, {:no_ack, n}}
+  defp validate_acking(:nack), do: {:ok, {:nack, 0}}
+  defp validate_acking({:nack, n}) when is_integer(n) and n >= 0, do: {:ok, {:nack, n}}
   defp validate_acking(_), do: :error
 
   defp validate_pull_request(opts) do

--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -94,7 +94,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
   end
 
   @impl Acknowledger
-  def configure(_channel, ack_data, options) do
+  def configure(_ack_ref, ack_data, options) do
     options = assert_valid_success_failure_opts!(options)
     ack_data = Map.merge(ack_data, Map.new(options))
     {:ok, ack_data}

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -76,8 +76,8 @@ defmodule BroadwayCloudPubSub.Producer do
 
   * `:ack` - Acknowledge the message. PubSub will mark the message as acked.
   * `:ignore` - Don't do anything. It won't notify to PubSub, and it will apply the default deadline.
-  * `:no_ack` - Change the deadline to 0 seconds.
-  * `{:no_ack, integer}` - Change the deadline to the seconds specified.
+  * `:nack` - Change the deadline to 0 seconds.
+  * `{:nack, integer}` - Change the deadline to the seconds specified.
 
 
   Read more about modifying the deadline of the messages [in the PubSub documentation](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline)

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -28,6 +28,14 @@ defmodule BroadwayCloudPubSub.Producer do
       to fetch an authentication token. It should return `{:ok, String.t()} | {:error, any()}`.
       Default generator uses `Goth.Token.for_scope/1` with `"https://www.googleapis.com/auth/pubsub"`.
 
+    * `:on_success` - Optional. Configures the acking behaviour for successful messages.
+       See the "Acking" section below for all the possible values. This option can also be changed for each
+       message through `Broadway.Message.configure_ack/2`. Defaults to `:ack`.
+
+    * `:on_failure` - Optional. Configures the acking messages for failed messages. See the "Acking" section
+       below for all the possible values. This option can also be changed for each message through
+       `Broadway.Message.configure_ack/2`. Defaults to `:ignore`
+
   ## Additional options
 
   These options applies to all producers, regardless of client implementation:
@@ -56,6 +64,23 @@ defmodule BroadwayCloudPubSub.Producer do
 
   The above configuration will set up a producer that continuously receives messages
   from `"projects/my-project/subscriptions/my_subscription"` and sends them downstream.
+
+  ## Acking
+
+  You can use the `:on_success` and `:on_failure` options to control how messages are acked on PubSub.
+  By default successful messages are acked and failed messages are ignored.
+  You can set `:on_success` and `:on_failure` when starting the PubSub producer,
+  or change them for each message through `Broadway.Message.configure_ack/2`
+
+  Here is the list of all possible values supported by `:on_success` and `:on_failure`:
+
+  * `:ack` - Acknowledge the message. PubSub will mark the message as acked.
+  * `:ignore` - Don't do anything. It won't notify to PubSub, and it will apply the default deadline.
+  * `:no_ack` - Change the deadline to 0 seconds.
+  * `{:no_ack, integer}` - Change the deadline to the seconds specified.
+
+
+  Read more about modifying the deadline of the messages [in the PubSub documentation](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline)
   """
 
   use GenStage

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule BroadwayCloudPubSub.MixProject do
 
   defp deps do
     [
-      {:broadway, "~> 0.4.0"},
+      {:broadway, github: "plataformatec/broadway"},
       {:google_api_pub_sub, "~> 0.11"},
       {:hackney, "~> 1.6"},
       {:goth, "~> 1.0", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], [], "hexpm"},
-  "broadway": {:hex, :broadway, "0.4.0", "b8daf580baed44347a9690449f9d8d7a308c1ca086648397d1a88eea893d047e", [:mix], [{:gen_stage, "~> 0.14", [hex: :gen_stage, repo: "hexpm", optional: false]}], "hexpm"},
+  "broadway": {:git, "https://github.com/plataformatec/broadway.git", "6fc8b9c25f6521b7d7aedf060ae032b36f91ba87", []},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.5", "0db71c8290b5bc81cb0101a2a507a76dca659513984d683119ee722828b424f6", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.1", "5ac36660846967cd869255f4426467a11672fec3d8db602c429425ce5b613b90", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/broadway_cloud_pub_sub/google_api_client_test.exs
+++ b/test/broadway_cloud_pub_sub/google_api_client_test.exs
@@ -326,17 +326,17 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
 
     test "set on_failure with deadline 0" do
       ack_data = %{ack_id: "1"}
-      expected = %{ack_id: "1", on_failure: {:no_ack, 0}}
+      expected = %{ack_id: "1", on_failure: {:nack, 0}}
 
-      assert {:ok, expected} == GoogleApiClient.configure(:channel, ack_data, on_failure: :no_ack)
+      assert {:ok, expected} == GoogleApiClient.configure(:channel, ack_data, on_failure: :nack)
     end
 
     test "set on_failure with custom deadline" do
       ack_data = %{ack_id: "1"}
-      expected = %{ack_id: "1", on_failure: {:no_ack, 60}}
+      expected = %{ack_id: "1", on_failure: {:nack, 60}}
 
       assert {:ok, expected} ==
-               GoogleApiClient.configure(:channel, ack_data, on_failure: {:no_ack, 60})
+               GoogleApiClient.configure(:channel, ack_data, on_failure: {:nack, 60})
     end
   end
 
@@ -388,7 +388,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
     } do
       {:ok, opts} = GoogleApiClient.init(base_opts)
 
-      messages = test_messages(opts, on_failure: {:no_ack, 0}, data: {:failed, :test})
+      messages = test_messages(opts, on_failure: {:nack, 0}, data: {:failed, :test})
       GoogleApiClient.ack(opts.ack_ref, [], messages)
 
       assert_received {:http_request_called, %{body: body, url: url}}

--- a/test/broadway_cloud_pub_sub/producer_test.exs
+++ b/test/broadway_cloud_pub_sub/producer_test.exs
@@ -151,16 +151,14 @@ defmodule BroadwayCloudPubSub.ProducerTest do
       Forwarder,
       name: new_unique_name(),
       context: %{test_pid: self()},
-      producers: [
-        default: [
-          module:
-            {BroadwayCloudPubSub.Producer,
-             client: FakeClient,
-             receive_interval: 0,
-             test_pid: self(),
-             message_server: message_server},
-          stages: 1
-        ]
+      producer: [
+        module:
+          {BroadwayCloudPubSub.Producer,
+           client: FakeClient,
+           receive_interval: 0,
+           test_pid: self(),
+           message_server: message_server},
+        stages: 1
       ],
       processors: [
         default: [stages: 1]


### PR DESCRIPTION
Related to plataformatec/broadway#108, plataformatec/broadway#109 and plataformatec/broadway_rabbitmq#42 (where I got my inspiration for this PR)

I added the basic operations, 
- `:ack`, current behaviour for success messages
- `:ignore`, current behaviour for failed messages, and set as the default for them
- `{:no_ack, integer}` Maybe it's better `:set_deadline` or `:deadline` ?
- `:no_ack`, a shortcut for `{:no_ack, 0}`, it probably can be removed 