### PR TITLE
Refactor: BroadwayCloudPubSub.ClientAcknowledger

### DIFF
--- a/lib/broadway_cloud_pub_sub/client.ex
+++ b/lib/broadway_cloud_pub_sub/client.ex
@@ -9,7 +9,25 @@ defmodule BroadwayCloudPubSub.Client do
 
   alias Broadway.Message
 
+  @typedoc """
+  A list of `Broadway.Message` structs.
+  """
   @type messages :: [Message.t()]
+
+  @typedoc """
+  The amount of time (in seconds) before Pub/Sub should reschedule a message.
+  """
+  @type ack_deadline :: 0..600
+
+  @typedoc """
+  The `ackId` returned by Pub/Sub to be used when acknowledging a message.
+  """
+  @type ack_id :: String.t()
+
+  @typedoc """
+  A list of `ackId` strings.
+  """
+  @type ack_ids :: list(ack_id)
 
   @doc """
   Invoked once by BroadwayCloudPubSub.Producer during `Broadway.start_link/2`.
@@ -23,7 +41,24 @@ defmodule BroadwayCloudPubSub.Client do
 
   @callback init(opts :: any) :: {:ok, normalized_opts :: any} | {:error, message :: binary}
 
+  @doc """
+  Dispatches a [`pull`](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull) request.
+  """
   @callback receive_messages(demand :: pos_integer, opts :: any) :: messages
 
-  @optional_callbacks prepare_to_connect: 2
+  @doc """
+  Dispatches a [`modifyAckDeadline`](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline) request.
+
+  This callback is required when integrating with the ClientAcknowledger.
+  """
+  @callback put_deadline(ack_ids, ack_deadline, opts :: any) :: any
+
+  @doc """
+  Dispatches an [`acknowledge`](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/acknowledge) request.
+
+  This callback is required when integrating with the ClientAcknowledger.
+  """
+  @callback acknowledge(ack_ids, opts :: any) :: any
+
+  @optional_callbacks acknowledge: 2, prepare_to_connect: 2, put_deadline: 3
 end

--- a/lib/broadway_cloud_pub_sub/client.ex
+++ b/lib/broadway_cloud_pub_sub/client.ex
@@ -49,14 +49,14 @@ defmodule BroadwayCloudPubSub.Client do
   @doc """
   Dispatches a [`modifyAckDeadline`](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline) request.
 
-  This callback is required when integrating with the ClientAcknowledger.
+  This callback is required when integrating with the `ClientAcknowledger`.
   """
   @callback put_deadline(ack_ids, ack_deadline, opts :: any) :: any
 
   @doc """
   Dispatches an [`acknowledge`](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/acknowledge) request.
 
-  This callback is required when integrating with the ClientAcknowledger.
+  This callback is required when integrating with the `ClientAcknowledger`.
   """
   @callback acknowledge(ack_ids, opts :: any) :: any
 

--- a/lib/broadway_cloud_pub_sub/client_acknowledger.ex
+++ b/lib/broadway_cloud_pub_sub/client_acknowledger.ex
@@ -1,0 +1,281 @@
+defmodule BroadwayCloudPubSub.ClientAcknowledger do
+  # This module implements the `Broadway.Acknowledger` behaviour,
+  # using the client for communication with Google CLoud Pub/Sub.
+  #
+  # ## Handling acknowledgements
+  #
+  # If you are writing a Pub/Sub client, instead of implementing the
+  # `Broadway.Acknowledger` behaviour directly, you can choose to integrate with
+  # the ClientAcknowledger. This will allow users of your client to use the same
+  # options and get the same behavior as outlined in the "Acknowledgements"
+  # section of the `BroadwayCloudPubSub.Producer` docs.
+
+  # To use the ClientAcknowledger with your client, initialize its configuration
+  # and build your client's `ack_ref` in `c:init/1`:
+
+  #     defmodule MyPubsubClient do
+  #       alias BroadwayCloudPubSub.Client
+  #       alias BroadwayCloudPubSub.ClientAcknowledger
+
+  #       @behaviour Client
+
+  #       @impl true
+  #       def init(opts) do
+  #         with {:ok, client_config} <- validate_config(opts),
+  #              {:ok, ack_config} <- ClientAcknowledger.init(opts) do
+  #           # Build an ack_ref with your client config
+  #           ack_ref = ClientAcknowledger.ack_ref(ack_config, client_config)
+
+  #           {:ok, Map.put(client_config, :ack_ref, ack_ref)}
+  #         end
+  #       end
+
+  # In `c:receive_messages/2`, build the `acknowledger` for each Message using the
+  # `ackId` from Cloud Pub/Sub message:
+
+  #       @impl true
+  #       def receive_messages(demand, config) do
+  #         case do_receive_messages(demand, config) do
+  #           {:ok, received_messages} ->
+  #             Enum.map(received_messages, fn message ->
+  #               %Broadway.Message{
+  #                 data: message.data,
+  #                 acknowledger: ClientAcknowledger.acknowledger(message.ackId, config.ack_ref)
+  #               }
+  #             end)
+  #           _ ->
+  #             []
+  #         end
+  #       end
+
+  # Finally, implement the optional callbacks `c:acknowledge/2`:
+
+  #       @impl true
+  #       def acknowledge(ack_ids, config) do
+  #         # dispatch an acknowledge request
+  #       end
+
+  # and `c:put_deadline/3`:
+
+  #       @impl true
+  #       def put_deadline(ack_ids, new_deadline, config) do
+  #         # dispatch a modifyAckDeadline request
+  #       end
+  #     end
+
+  # These callbacks will be used by the ClientAcknowledger to dispatch requests
+  # to Google Cloud Pub/Sub.
+  @moduledoc false
+  alias Broadway.{Acknowledger, TermStorage}
+  alias BroadwayCloudPubSub.Client
+
+  @behaviour Acknowledger
+
+  @typedoc """
+  Ackmowledgement data for a `Broadway.Message`.
+  """
+  @type ack_data :: %{
+          :ack_id => String.t(),
+          optional(:on_failure) => ack_option,
+          optional(:on_success) => ack_option
+        }
+
+  @typedoc """
+  An acknowledgement action.
+  """
+  @type ack_option :: :ack | :ignore | :nack | {:nack, Client.ack_deadline()}
+
+  @type ack_ref :: reference
+
+  @type t :: %__MODULE__{
+          :client => module,
+          :client_opts => any,
+          :on_failure => ack_option,
+          :on_success => ack_option
+        }
+
+  @enforce_keys [:client]
+  defstruct [:client, :client_opts, on_failure: :ignore, on_success: :ack]
+
+  @doc """
+  Initializes this acknowledger for use with a `BroadwayCloudPubSub.Client`.
+
+  ## Options
+
+  The following options are usually provided by `BroadwayCloudPubSub.Producer`:
+
+    * `client` - The client module integrating with the #{inspect(__MODULE__)}.
+
+    * `on_success` - Optional. The action to perform for successful messages. Default is `:ack`.
+
+    * `on_failure` - The action to perform for failed messages. Default is `:ignore`.
+  """
+  @spec init(opts :: any) :: {:ok, t} | {:error, message :: binary}
+  def init(opts) do
+    with {:ok, client} <- validate(opts, :client),
+         {:ok, on_success} <- validate(opts, :on_success, :ack),
+         {:ok, on_failure} <- validate(opts, :on_failure, :ignore) do
+      {:ok,
+       %__MODULE__{
+         client: client,
+         on_failure: on_failure,
+         on_success: on_success
+       }}
+    end
+  end
+
+  @doc """
+  Creates a reference that can be passed to `acknowledger/2`.
+
+  The client configuration is stored in `Broadway.TermStorage`.
+  """
+  @spec ack_ref(config :: t, client_opts :: any) :: ack_ref
+  def ack_ref(config, client_opts) do
+    TermStorage.put(%{config | client_opts: client_opts})
+  end
+
+  @doc """
+  Returns an `acknowledger` to be put on a `Broadway.Message`.
+
+  ## Example
+
+      iex> BroadwayCloudPubSub.ClientAcknowledger.acknowledger("ackId", :ack_ref)
+      {BroadwayCloudPubSub.ClientAcknowledger, :ack_ref, %{ack_id: "ackId"}}
+
+  """
+  @spec acknowledger(ack_id :: Client.ack_id(), ack_ref) :: {__MODULE__, ack_ref, ack_data}
+  def acknowledger(ack_id, ack_ref) do
+    {__MODULE__, ack_ref, %{ack_id: ack_id}}
+  end
+
+  @impl Acknowledger
+  def ack(ack_ref, successful, failed) do
+    config = Broadway.TermStorage.get!(ack_ref)
+
+    ack_messages(successful, :on_success, config)
+    ack_messages(failed, :on_failure, config)
+
+    :ok
+  end
+
+  @impl Acknowledger
+  def configure(_ack_ref, ack_data, options) do
+    options = assert_valid_config!(options)
+    ack_data = Map.merge(ack_data, Map.new(options))
+    {:ok, ack_data}
+  end
+
+  defp assert_valid_config!(options) do
+    Enum.map(options, fn
+      {:on_success, value} -> {:on_success, validate_option!(:on_success, value)}
+      {:on_failure, value} -> {:on_failure, validate_option!(:on_failure, value)}
+      {other, _value} -> raise ArgumentError, "unsupported configure option #{inspect(other)}"
+    end)
+  end
+
+  defp ack_messages([], _key, _config), do: :ok
+
+  defp ack_messages(messages, key, config) do
+    messages
+    |> Enum.group_by(&group_acknowledger(&1, key, config), &extract_ack_id/1)
+    |> Enum.map(fn {action, ack_ids} ->
+      apply_ack_func(ack_ids, action, config)
+    end)
+  end
+
+  defp group_acknowledger(%{acknowledger: {_, _, ack_data}}, key, config) do
+    Map.get_lazy(ack_data, key, fn -> config_action(key, config) end)
+  end
+
+  defp config_action(:on_success, %{on_success: action}), do: action
+  defp config_action(:on_failure, %{on_failure: action}), do: action
+
+  defp extract_ack_id(message) do
+    {_, _, %{ack_id: ack_id}} = message.acknowledger
+    ack_id
+  end
+
+  defp apply_ack_func(:ignore, _ack_ids, _opts), do: :ok
+
+  defp apply_ack_func(:ack, ack_ids, opts) do
+    %{client: {client, client_opts}} = opts
+
+    client.acknowledge(ack_ids, client_opts)
+  end
+
+  defp apply_ack_func(:nack, ack_ids, opts),
+    do: apply_ack_func({:nack, 0}, ack_ids, opts)
+
+  defp apply_ack_func({:nack, deadline}, ack_ids, opts) do
+    %{client: {client, client_opts}} = opts
+
+    client.put_deadline(ack_ids, deadline, client_opts)
+  end
+
+  defp validate(opts, key, default \\ nil) when is_list(opts) do
+    validate_option(key, opts[key] || default)
+  end
+
+  defp validate_option(:client, client) when not is_atom(client) do
+    validation_error(:client, "a module implementing #{inspect(Client)}", client)
+  end
+
+  defp validate_option(:client, client) when client in [true, nil] do
+    validation_error(:client, "a module implementing #{inspect(Client)}", client)
+  end
+
+  defp validate_option(:client, client) do
+    with {:loaded, true} <- {:loaded, Code.ensure_compiled?(client)},
+         {:acknowledger, {:error, _}} <- {:acknowledger, validate_exported(client, :ack, 3)},
+         {:ok, _} <- validate_exported(client, :acknowledge, 2),
+         {:ok, _} <- validate_exported(client, :put_deadline, 3) do
+      {:ok, client}
+    else
+      {:loaded, false} ->
+        {:error, "the client #{inspect(client)} does not exist or could not be loaded"}
+
+      {:acknowledger, _} ->
+        {:error,
+         "the client #{inspect(client)} is attempting to call #{inspect(__MODULE__)}.init/1, but the client itself implements the #{
+           inspect(Acknowledger)
+         } behaviour"}
+
+      other ->
+        other
+    end
+  end
+
+  defp validate_option(action, value) when action in [:on_success, :on_failure] do
+    case validate_action(value) do
+      {:ok, result} -> {:ok, result}
+      :error -> validation_error(action, "a valid acknowledgement option", value)
+    end
+  end
+
+  defp validate_option(_, value), do: {:ok, value}
+
+  defp validate_option!(key, value) do
+    case validate_option(key, value) do
+      {:ok, value} -> value
+      {:error, message} -> raise ArgumentError, message
+    end
+  end
+
+  defp validate_exported(client, function, arity) do
+    if function_exported?(client, function, arity) do
+      {:ok, client}
+    else
+      {:error, "#{inspect(client)}.#{function}/#{arity} is undefined or private"}
+    end
+  end
+
+  defp validation_error(option, expected, value) do
+    {:error, "expected #{inspect(option)} to be #{expected}, got: #{inspect(value)}"}
+  end
+
+  defp validate_action(:ack), do: {:ok, :ack}
+  defp validate_action(:ignore), do: {:ok, :ignore}
+  defp validate_action(:nack), do: {:ok, {:nack, 0}}
+  defp validate_action({:nack, n}) when is_integer(n) and n >= 0, do: {:ok, {:nack, n}}
+  defp validate_action(_), do: :error
+end

--- a/lib/broadway_cloud_pub_sub/client_acknowledger.ex
+++ b/lib/broadway_cloud_pub_sub/client_acknowledger.ex
@@ -1,6 +1,6 @@
 defmodule BroadwayCloudPubSub.ClientAcknowledger do
   # This module implements the `Broadway.Acknowledger` behaviour,
-  # using the client for communication with Google CLoud Pub/Sub.
+  # using the client for communication with Google Cloud Pub/Sub.
   #
   # ## Handling acknowledgements
   #
@@ -21,12 +21,12 @@ defmodule BroadwayCloudPubSub.ClientAcknowledger do
 
   #       @impl true
   #       def init(opts) do
-  #         with {:ok, client_config} <- validate_config(opts),
-  #              {:ok, ack_config} <- ClientAcknowledger.init(opts) do
+  #         with {:ok, config} <- validate_config(opts),
+  #              {:ok, ack} <- ClientAcknowledger.init(opts) do
   #           # Build an ack_ref with your client config
-  #           ack_ref = ClientAcknowledger.ack_ref(ack_config, client_config)
+  #           ack_ref = ClientAcknowledger.ack_ref(ack, config)
 
-  #           {:ok, Map.put(client_config, :ack_ref, ack_ref)}
+  #           {:ok, %{config | ack_ref: ack_ref}}
   #         end
   #       end
 
@@ -72,7 +72,7 @@ defmodule BroadwayCloudPubSub.ClientAcknowledger do
   @behaviour Acknowledger
 
   @typedoc """
-  Ackmowledgement data for a `Broadway.Message`.
+  Acknowledgement data for a `Broadway.Message`.
   """
   @type ack_data :: %{
           :ack_id => String.t(),
@@ -90,8 +90,8 @@ defmodule BroadwayCloudPubSub.ClientAcknowledger do
   @type t :: %__MODULE__{
           :client => module,
           :client_opts => any,
-          :on_failure => ack_option,
-          :on_success => ack_option
+          :on_failure => ack_option(),
+          :on_success => ack_option()
         }
 
   @enforce_keys [:client]
@@ -157,7 +157,7 @@ defmodule BroadwayCloudPubSub.ClientAcknowledger do
 
   @impl Acknowledger
   def ack(ack_ref, successful, failed) do
-    config = Broadway.TermStorage.get!(ack_ref)
+    config = TermStorage.get!(ack_ref)
 
     success_actions = group_actions_ack_ids(successful, :on_success, config)
     failure_actions = group_actions_ack_ids(failed, :on_failure, config)

--- a/lib/broadway_cloud_pub_sub/client_acknowledger.ex
+++ b/lib/broadway_cloud_pub_sub/client_acknowledger.ex
@@ -90,8 +90,8 @@ defmodule BroadwayCloudPubSub.ClientAcknowledger do
   @type t :: %__MODULE__{
           :client => module,
           :client_opts => any,
-          :on_failure => ack_option(),
-          :on_success => ack_option()
+          :on_failure => ack_option,
+          :on_success => ack_option
         }
 
   @enforce_keys [:client]

--- a/lib/broadway_cloud_pub_sub/client_acknowledger.ex
+++ b/lib/broadway_cloud_pub_sub/client_acknowledger.ex
@@ -194,8 +194,10 @@ defmodule BroadwayCloudPubSub.ClientAcknowledger do
   end
 
   defp ack_messages(actions_and_ids, config) do
-    Enum.map(actions_and_ids, fn {action, ack_ids} ->
-      apply_ack_func(action, ack_ids, config)
+    Enum.each(actions_and_ids, fn {action, ack_ids} ->
+      ack_ids
+      |> Enum.chunk_every(3_000)
+      |> Enum.each(&apply_ack_func(action, &1, config))
     end)
   end
 
@@ -206,9 +208,6 @@ defmodule BroadwayCloudPubSub.ClientAcknowledger do
 
     client.acknowledge(ack_ids, opts)
   end
-
-  defp apply_ack_func(:nack, ack_ids, config),
-    do: apply_ack_func({:nack, 0}, ack_ids, config)
 
   defp apply_ack_func({:nack, deadline}, ack_ids, config) do
     %__MODULE__{client: client, client_opts: opts} = config

--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -68,7 +68,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
     with {:ok, subscription} <- validate_subscription(opts),
          {:ok, token_generator} <- validate_token_opts(opts),
          {:ok, pull_request} <- validate_pull_request(opts),
-         {:ok, ack_config} <- ClientAcknowledger.init([client: __MODULE__] ++ opts) do
+         {:ok, ack} <- ClientAcknowledger.init([client: __MODULE__] ++ opts) do
       adapter = Keyword.get(opts, :__internal_tesla_adapter__, Hackney)
       connection_pool = Keyword.get(opts, :__connection_pool__, :default)
 
@@ -79,7 +79,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
         token_generator: token_generator
       }
 
-      ack_ref = ClientAcknowledger.ack_ref(ack_config, config)
+      ack_ref = ClientAcknowledger.ack_ref(ack, config)
 
       {:ok, Map.merge(config, %{ack_ref: ack_ref, pull_request: pull_request})}
     end

--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -6,22 +6,23 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
   """
 
   import GoogleApi.PubSub.V1.Api.Projects
-  alias Broadway.{Message, Acknowledger}
-  alias BroadwayCloudPubSub.Client
+  alias Broadway.Message
+  alias BroadwayCloudPubSub.{Client, ClientAcknowledger}
   alias GoogleApi.PubSub.V1.Connection
 
   alias GoogleApi.PubSub.V1.Model.{
-    PullRequest,
     AcknowledgeRequest,
     ModifyAckDeadlineRequest,
-    PubsubMessage
+    PubsubMessage,
+    PullResponse,
+    PullRequest,
+    ReceivedMessage
   }
 
   alias Tesla.Adapter.Hackney
   require Logger
 
   @behaviour Client
-  @behaviour Acknowledger
 
   @default_max_number_of_messages 10
 
@@ -67,32 +68,20 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
     with {:ok, subscription} <- validate_subscription(opts),
          {:ok, token_generator} <- validate_token_opts(opts),
          {:ok, pull_request} <- validate_pull_request(opts),
-         {:ok, on_success} <- validate(opts, :on_success, :ack),
-         {:ok, on_failure} <- validate(opts, :on_failure, :ignore) do
+         {:ok, ack_config} <- ClientAcknowledger.init([client: __MODULE__] ++ opts) do
       adapter = Keyword.get(opts, :__internal_tesla_adapter__, Hackney)
       connection_pool = Keyword.get(opts, :__connection_pool__, :default)
 
-      storage_ref =
-        Broadway.TermStorage.put(%{
-          adapter: adapter,
-          connection_pool: connection_pool,
-          subscription: subscription,
-          token_generator: token_generator
-        })
+      config = %{
+        adapter: adapter,
+        connection_pool: connection_pool,
+        subscription: subscription,
+        token_generator: token_generator
+      }
 
-      ack_ref = {__MODULE__, storage_ref}
+      ack_ref = ClientAcknowledger.ack_ref(ack_config, config)
 
-      {:ok,
-       %{
-         adapter: adapter,
-         connection_pool: connection_pool,
-         subscription: subscription,
-         token_generator: token_generator,
-         pull_request: pull_request,
-         ack_ref: ack_ref,
-         on_success: on_success,
-         on_failure: on_failure
-       }}
+      {:ok, Map.merge(config, %{ack_ref: ack_ref, pull_request: pull_request})}
     end
   end
 
@@ -107,54 +96,12 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
       opts.subscription.subscriptions_id,
       body: pull_request
     )
-    |> wrap_received_messages(opts.ack_ref, opts)
+    |> handle_response(:receive_messages)
+    |> wrap_received_messages(opts.ack_ref)
   end
 
-  @impl Acknowledger
-  def ack(ack_ref, successful, failed) do
-    ack_messages(successful, ack_ref, :successful)
-    ack_messages(failed, ack_ref, :failed)
-  end
-
-  @impl Acknowledger
-  def configure(_ack_ref, ack_data, options) do
-    options = assert_valid_success_failure_opts!(options)
-    ack_data = Map.merge(ack_data, Map.new(options))
-    {:ok, ack_data}
-  end
-
-  defp assert_valid_success_failure_opts!(options) do
-    Enum.map(options, fn
-      {:on_success, value} -> {:on_success, validate_option!(:on_success, value)}
-      {:on_failure, value} -> {:on_failure, validate_option!(:on_failure, value)}
-      {other, _value} -> raise ArgumentError, "unsupported configure option #{inspect(other)}"
-    end)
-  end
-
-  defp ack_messages([], _ref, _kind), do: :ok
-
-  defp ack_messages(messages, {_pid, ref}, kind) do
-    opts = Broadway.TermStorage.get!(ref)
-
-    messages
-    |> Enum.group_by(&group_acknowledger(&1, kind))
-    |> Enum.map(fn {action, messages} ->
-      action |> apply_ack_func(messages, opts) |> handle_acknowledged_messages()
-    end)
-  end
-
-  defp group_acknowledger(%{acknowledger: {_mod, _chan, ack_data}}, kind) do
-    ack_data_action(ack_data, kind)
-  end
-
-  defp ack_data_action(%{on_success: action}, :successful), do: action
-  defp ack_data_action(%{on_failure: action}, :failed), do: action
-
-  defp apply_ack_func(:ignore, _messages, _opts), do: :ok
-
-  defp apply_ack_func(:ack, messages, opts) do
-    ack_ids = Enum.map(messages, &extract_ack_id/1)
-
+  @impl Client
+  def acknowledge(ack_ids, opts) do
     opts
     |> conn!()
     |> pubsub_projects_subscriptions_acknowledge(
@@ -162,14 +109,11 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
       opts.subscription.subscriptions_id,
       body: %AcknowledgeRequest{ackIds: ack_ids}
     )
+    |> handle_response(:acknowledge)
   end
 
-  defp apply_ack_func(:nack, messages, opts),
-    do: apply_ack_func({:nack, 0}, messages, opts)
-
-  defp apply_ack_func({:nack, deadline}, messages, opts) do
-    ack_ids = Enum.map(messages, &extract_ack_id/1)
-
+  @impl Client
+  def put_deadline(ack_ids, deadline, opts) when deadline in 0..600 do
     opts
     |> conn!()
     |> pubsub_projects_subscriptions_modify_ack_deadline(
@@ -177,51 +121,59 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
       opts.subscription.subscriptions_id,
       body: %ModifyAckDeadlineRequest{ackDeadlineSeconds: deadline, ackIds: ack_ids}
     )
+    |> handle_response(:put_deadline)
   end
 
-  defp handle_acknowledged_messages(:ok), do: :ok
+  # The typespec for PullResponse is too strict. If Pub/Sub returns an empty
+  # response, then `receivedMessages` will be nil.
+  defp handle_response({:ok, %PullResponse{receivedMessages: nil}}, :receive_messages) do
+    []
+  end
 
-  defp handle_acknowledged_messages({:ok, _}), do: :ok
+  defp handle_response({:ok, response}, :receive_messages) do
+    %PullResponse{receivedMessages: received_messages} = response
+    received_messages
+  end
 
-  defp handle_acknowledged_messages({:error, reason}) do
-    Logger.error("Unable to acknowledge messages with Cloud Pub/Sub. Reason: #{inspect(reason)}")
+  defp handle_response({:ok, _}, _), do: :ok
+
+  defp handle_response({:error, reason}, :receive_messages) do
+    Logger.error("Unable to fetch events from Cloud Pub/Sub. Reason: #{inspect(reason)}")
+    []
+  end
+
+  defp handle_response({:error, reason}, :acknowledge) do
+    Logger.error("Unable to acknowledge messages with Cloud Pub/Sub, reason: #{inspect(reason)}")
     :ok
   end
 
-  defp wrap_received_messages({:ok, %{receivedMessages: received_messages}}, ack_ref, opts)
-       when is_list(received_messages) do
-    Enum.map(received_messages, fn %{message: message, ackId: ack_id} ->
+  defp handle_response({:error, reason}, :put_deadline) do
+    Logger.error("Unable to put new ack deadline with Cloud Pub/Sub, reason: #{inspect(reason)}")
+    :ok
+  end
+
+  defp wrap_received_messages(received_messages, ack_ref) do
+    Enum.map(received_messages, fn received_message ->
+      %ReceivedMessage{message: message, ackId: ack_id} = received_message
+
       {data, metadata} =
         message
         |> decode_message()
         |> Map.from_struct()
         |> Map.pop(:data)
 
-      ack_data = %{ack_id: ack_id, on_success: opts.on_success, on_failure: opts.on_failure}
-
       %Message{
         data: data,
         metadata: metadata,
-        acknowledger: {__MODULE__, ack_ref, ack_data}
+        acknowledger: ClientAcknowledger.acknowledger(ack_id, ack_ref)
       }
     end)
-  end
-
-  defp wrap_received_messages({:ok, _}, _ack_ref, _opts) do
-    []
-  end
-
-  defp wrap_received_messages({:error, reason}, _, _) do
-    Logger.error("Unable to fetch events from Cloud Pub/Sub. Reason: #{inspect(reason)}")
-    []
   end
 
   defp decode_message(%PubsubMessage{data: nil} = message), do: message
 
   defp decode_message(%PubsubMessage{data: encoded_data} = message) do
-    data = Base.decode64!(encoded_data)
-
-    put_in(message.data, data)
+    %{message | data: Base.decode64!(encoded_data)}
   end
 
   defp put_max_number_of_messages(pull_request, demand) do
@@ -230,20 +182,8 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
     %{pull_request | maxMessages: max_number_of_messages}
   end
 
-  defp extract_ack_id(message) do
-    {_, _, %{ack_id: ack_id}} = message.acknowledger
-    ack_id
-  end
-
   defp validate(opts, key, default \\ nil) when is_list(opts) do
     validate_option(key, opts[key] || default)
-  end
-
-  defp validate_option!(key, value) do
-    case validate_option(key, value) do
-      {:ok, value} -> value
-      {:error, message} -> raise ArgumentError, message
-    end
   end
 
   defp validate_option(:token_generator, {m, f, args})
@@ -268,24 +208,11 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
   defp validate_option(:return_immediately, value) when not is_boolean(value),
     do: validation_error(:return_immediately, "a boolean value", value)
 
-  defp validate_option(action, value) when action in [:on_success, :on_failure] do
-    case validate_acking(value) do
-      {:ok, result} -> {:ok, result}
-      :error -> validation_error(action, "a valid #{action} value", value)
-    end
-  end
-
   defp validate_option(_, value), do: {:ok, value}
 
   defp validation_error(option, expected, value) do
     {:error, "expected #{inspect(option)} to be #{expected}, got: #{inspect(value)}"}
   end
-
-  defp validate_acking(:ack), do: {:ok, :ack}
-  defp validate_acking(:ignore), do: {:ok, :ignore}
-  defp validate_acking(:nack), do: {:ok, {:nack, 0}}
-  defp validate_acking({:nack, n}) when is_integer(n) and n >= 0, do: {:ok, {:nack, n}}
-  defp validate_acking(_), do: :error
 
   defp validate_pull_request(opts) do
     with {:ok, return_immediately} <- validate(opts, :return_immediately),

--- a/test/broadway_cloud_pub_sub/client_acknowledger_test.exs
+++ b/test/broadway_cloud_pub_sub/client_acknowledger_test.exs
@@ -1,0 +1,199 @@
+defmodule BroadwayCloudPubSub.ClientAcknowledgerTest do
+  use ExUnit.Case
+  alias BroadwayCloudPubSub.Client
+  alias BroadwayCloudPubSub.ClientAcknowledger
+
+  doctest ClientAcknowledger
+
+  defmodule ClientWithOnlyAcknowledge do
+    @behaviour Client
+
+    @impl Client
+    def init(opts), do: {:ok, opts}
+
+    @impl Client
+    def receive_messages(_demand, _opts), do: []
+
+    @impl Client
+    def acknowledge(_ack_ids, _opts), do: :ok
+  end
+
+  defmodule ClientWithOnlyPut do
+    @behaviour Client
+
+    @impl Client
+    def init(opts), do: {:ok, opts}
+
+    @impl Client
+    def receive_messages(_demand, _opts), do: []
+
+    @impl Client
+    def put_deadline(_ack_ids, _deadline, _opts), do: :ok
+  end
+
+  defmodule ClientWithBroadwayAcknowledger do
+    alias Broadway.Acknowledger
+
+    @behaviour Client
+    @behaviour Acknowledger
+
+    @impl Client
+    def init(opts), do: {:ok, opts}
+
+    @impl Client
+    def receive_messages(_demand, _opts), do: []
+
+    @impl Acknowledger
+    def ack(_ack_ref, _successful, _failed), do: :ok
+  end
+
+  defmodule CallerClient do
+    alias BroadwayCloudPubSub.ClientAcknowledger
+
+    @behaviour Client
+
+    @impl Client
+    def init(opts) do
+      with {:ok, ack_config} <- ClientAcknowledger.init(opts) do
+        config = %{test_pid: opts[:test_pid]}
+        ack_ref = ClientAcknowledger.ack_ref(ack_config, config)
+
+        {:ok, Map.put(config, :ack_ref, ack_ref)}
+      end
+    end
+
+    @impl Client
+    def receive_messages(_demand, _opts), do: []
+
+    @impl Client
+    def acknowledge(ack_ids, opts) do
+      send(opts.test_pid, {:acknowledge, length(ack_ids)})
+    end
+
+    @impl Client
+    def put_deadline(ack_ids, deadline, opts) do
+      send(opts.test_pid, {{:put_deadline, deadline}, length(ack_ids)})
+    end
+  end
+
+  describe "init/1" do
+    test "when client is not an atom, returns error" do
+      assert ClientAcknowledger.init(client: "a string") ==
+               {:error,
+                "expected :client to be a module implementing #{inspect(Client)}, got: \"a string\""}
+
+      assert ClientAcknowledger.init(client: nil) ==
+               {:error,
+                "expected :client to be a module implementing #{inspect(Client)}, got: nil"}
+
+      assert ClientAcknowledger.init(client: true) ==
+               {:error,
+                "expected :client to be a module implementing #{inspect(Client)}, got: true"}
+
+      assert ClientAcknowledger.init(client: false) ==
+               {:error,
+                "expected :client to be a module implementing #{inspect(Client)}, got: nil"}
+    end
+
+    test "when client does not exist, returns error" do
+      assert ClientAcknowledger.init(client: DoesNotExistClient) ==
+               {:error, "the client DoesNotExistClient does not exist or could not be loaded"}
+    end
+
+    test "when client implements Broadway.Acknowledger, returns error" do
+      assert ClientAcknowledger.init(client: ClientWithBroadwayAcknowledger) ==
+               {:error,
+                "the client #{inspect(ClientWithBroadwayAcknowledger)} is attempting to call #{
+                  inspect(ClientAcknowledger)
+                }.init/1, but the client itself implements the Broadway.Acknowledger behaviour"}
+    end
+
+    test "when client has only acknowledge/2, returns error" do
+      assert ClientAcknowledger.init(client: ClientWithOnlyAcknowledge) ==
+               {:error,
+                "#{inspect(ClientWithOnlyAcknowledge)}.put_deadline/3 is undefined or private"}
+    end
+
+    test "when client has only put_deadline/3, returns error" do
+      assert ClientAcknowledger.init(client: ClientWithOnlyPut) ==
+               {:error, "#{inspect(ClientWithOnlyPut)}.acknowledge/2 is undefined or private"}
+    end
+
+    test "with valid client, returns config with default actions" do
+      assert ClientAcknowledger.init(client: CallerClient) ==
+               {:ok,
+                %ClientAcknowledger{
+                  client: CallerClient,
+                  client_opts: nil,
+                  on_failure: :ignore,
+                  on_success: :ack
+                }}
+    end
+
+    test "with valid options, returns config with custom actions" do
+      assert ClientAcknowledger.init(client: CallerClient, on_success: :ignore, on_failure: :nack) ==
+               {:ok,
+                %ClientAcknowledger{
+                  client: CallerClient,
+                  client_opts: nil,
+                  on_failure: {:nack, 0},
+                  on_success: :ignore
+                }}
+    end
+  end
+
+  describe "configure/3" do
+    test "raise on unsupported configure option" do
+      assert_raise(ArgumentError, "unsupported configure option :on_other", fn ->
+        ClientAcknowledger.configure(:ack_ref, %{}, on_other: :ack)
+      end)
+    end
+
+    test "raise on unsupported on_success value" do
+      error_msg = "expected :on_success to be a valid acknowledgement option, got: :unknown"
+
+      assert_raise(ArgumentError, error_msg, fn ->
+        ClientAcknowledger.configure(:ack_ref, %{}, on_success: :unknown)
+      end)
+    end
+
+    test "raise on unsupported on_failure value" do
+      error_msg = "expected :on_failure to be a valid acknowledgement option, got: :unknown"
+
+      assert_raise(ArgumentError, error_msg, fn ->
+        ClientAcknowledger.configure(:ack_ref, %{}, on_failure: :unknown)
+      end)
+    end
+
+    test "set on_success correctly" do
+      ack_data = %{ack_id: "1"}
+      expected = %{ack_id: "1", on_success: :ack}
+
+      assert {:ok, expected} == ClientAcknowledger.configure(:ack_ref, ack_data, on_success: :ack)
+    end
+
+    test "set on_success with ignore" do
+      ack_data = %{ack_id: "1"}
+      expected = %{ack_id: "1", on_success: :ignore}
+
+      assert {:ok, expected} ==
+               ClientAcknowledger.configure(:ack_ref, ack_data, on_success: :ignore)
+    end
+
+    test "set on_failure with deadline 0" do
+      ack_data = %{ack_id: "1"}
+      expected = %{ack_id: "1", on_failure: {:nack, 0}}
+
+      assert {:ok, expected} ==
+               ClientAcknowledger.configure(:ack_ref, ack_data, on_failure: :nack)
+    end
+
+    test "set on_failure with custom deadline" do
+      ack_data = %{ack_id: "1"}
+      expected = %{ack_id: "1", on_failure: {:nack, 60}}
+
+      assert {:ok, expected} ==
+               ClientAcknowledger.configure(:ack_ref, ack_data, on_failure: {:nack, 60})
+    end
+  end
+end


### PR DESCRIPTION
`BroadwayCloudPubSub.ClientAcknowledger` handles acknowledgement option validation, implementing the `Broadway.Acknowledger` behaviour and delegating back to the calling Client to dispatch the proper API requests.

This is an effort to 1) separate the concerns of client requests and acknowledger logic, 2) allow those implementing their own clients to get the benefit of the existing acknowledger behaviour.

Thanks again for adding the new acknowledgement options, @rockneurotiko -- I'd love to get your feedback here, too. There shouldn't be any functional change from your original PR.